### PR TITLE
feat/1020: 대기실 오브젝트 추가 배치 완료

### DIFF
--- a/src/components/WaitingRoom/index.js
+++ b/src/components/WaitingRoom/index.js
@@ -129,6 +129,30 @@ function WaitingRoom({ hexCode, user, startGameFn }) {
               setReadyUsers={setReadyUsers}
               setIsUsersReady={setIsUsersReady}
             />
+            <ParkingZone
+              rotation={[-Math.PI / 2, 0, 0]}
+              position={[10, 0.1, -15]}
+              userData={{ id: "parking" }}
+              startGameFn={() => {
+                startGameFn("/gameroom1");
+              }}
+              user={user}
+              readyUsers={readyUsers}
+              setReadyUsers={setReadyUsers}
+              setIsUsersReady={setIsUsersReady}
+            />
+            <ParkingZone
+              rotation={[-Math.PI / 2, 0, 0]}
+              position={[20, 0.1, -15]}
+              userData={{ id: "parking" }}
+              startGameFn={() => {
+                startGameFn("/gameroom1");
+              }}
+              user={user}
+              readyUsers={readyUsers}
+              setReadyUsers={setReadyUsers}
+              setIsUsersReady={setIsUsersReady}
+            />
             <Pillar position={[5, 2.5, 0]} userData={{ id: "pillar-1" }} />
             <Pillar position={[-20, 5, -5]} userData={{ id: "pillar-2" }} />
             <Sphere position={[20, 20, -5]} userData={{ id: "sphere-1" }} />
@@ -161,6 +185,18 @@ function WaitingRoom({ hexCode, user, startGameFn }) {
             <Bush position={[-10, 0, -20]} userData={{ id: "bush-13" }} />
             <Bush position={[-15, 0, -15]} userData={{ id: "bush-14" }} />
             <Bush position={[0, 0, -20]} userData={{ id: "bush-15" }} />
+            <Bush position={[15, 0, -12]} userData={{ id: "bush-16" }} />
+            <Bush position={[15, 0, -18]} userData={{ id: "bush-17" }} />
+            <Bush position={[15, 0, -15]} userData={{ id: "bush-18" }} />
+            <Bush position={[13, 0, -20]} userData={{ id: "bush-19" }} />
+            <Bush position={[10, 0, -20]} userData={{ id: "bush-20" }} />
+            <Bush position={[7, 0, -20]} userData={{ id: "bush-21" }} />
+            <Bush position={[17, 0, -20]} userData={{ id: "bush-22" }} />
+            <Bush position={[20, 0, -20]} userData={{ id: "bush-23" }} />
+            <Bush position={[23, 0, -20]} userData={{ id: "bush-24" }} />
+            <Bush position={[25, 0, -12]} userData={{ id: "bush-25" }} />
+            <Bush position={[25, 0, -18]} userData={{ id: "bush-26" }} />
+            <Bush position={[25, 0, -15]} userData={{ id: "bush-27" }} />
             <RoadSign
               position={[-8, 0, 0]}
               userData={{ id: "ROADWORKS_PREPARE-TO-STOP" }}


### PR DESCRIPTION
## 개요

- [칸반링크](https://www.notion.so/vanillacoding/604112c78fd64596910f671734671291)
- 팀원들과 협의한 대로 ParkingZone 두 개를 추가 배치하였습니다. ParkingZone의 경우 일종의 Portal로서
  gameroom으로의 이동을 가능케 해주는 공간입니다. 

## 작업사항

- ![image](https://user-images.githubusercontent.com/93423531/173578037-5a44d9a0-4fcc-444b-86c5-4ba0bb7224b9.png)

## 변경로직

- 스크린샷에 보이는 바와 같이 두 개의 ParkingZone이 추가 배치되었습니다. 

## 리뷰시 체크리스트

- 배치된 오브젝트 간 간격이 일정한지에 대한 여부 등

## 기타

- 이외에도 추가 배치, 혹은 오브젝트의 위치 변경 등 해당 작업에 대한 아이디어가 있을 시 공유 부탁드립니다. 
