### PR TITLE
Fix/5008: 채팅소켓 연결 url 수정

### DIFF
--- a/src/components/ChatRoom/index.js
+++ b/src/components/ChatRoom/index.js
@@ -176,7 +176,7 @@ function ChatRoom({
   }, [contents.length]);
 
   useEffect(() => {
-    const socket = io.connect(`${process.env.SERVER_URL}`, {
+    const socket = io.connect(`${process.env.REACT_APP_SERVER_URL}`, {
       withCredentials: true,
     });
 


### PR DESCRIPTION
## 개요

-[ 칸반링크](https://www.notion.so/vanillacoding/a813b207913b4f0f96b1f72162f0c417)
- 배포하면서 변수명을 환경변수로 만드는 과정에서 오타가 있어서 url값에 정상적으로 값이 들어가지 않았었습니다. 해당사항 수정하였습니다

## 작업사항

- 오타 수정

## 변경로직

- ChatRoom/index.js 파일의 소켓연결코드 url의 환경변수 오타수정
