### PR TITLE
Feat/1026: 로딩화면 추가

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, Suspense } from "react";
 import { onAuthStateChanged } from "firebase/auth";
 import { authService } from "./config/auth/firebase";
 import { Routes, Route, Navigate, useNavigate } from "react-router-dom";
@@ -10,6 +10,7 @@ import Logout from "./components/Logout";
 import GameRoom from "./components/GameRoom";
 import BackSVGGame from "./components/GameRoom/BackSVGGame";
 import WaitingRoom from "./components/WaitingRoom";
+import { Loader } from "@react-three/drei";
 
 const GameLayout = styled.div`
   position: fixed;
@@ -92,18 +93,23 @@ function App() {
           path="/"
           element={
             auth ? (
-              <Main
-                hexCode={hexCode}
-                setHexCode={setHexCode}
-                user={user}
-                token={token}
-                isGameMode={isGameMode}
-                setIsGameMode={setIsGameMode}
-                myData={myData}
-                setMyData={setMyData}
-                isMute={isMute}
-                setIsMute={setIsMute}
-              />
+              <>
+                <Suspense fallback={null}>
+                  <Main
+                    hexCode={hexCode}
+                    setHexCode={setHexCode}
+                    user={user}
+                    token={token}
+                    isGameMode={isGameMode}
+                    setIsGameMode={setIsGameMode}
+                    myData={myData}
+                    setMyData={setMyData}
+                    isMute={isMute}
+                    setIsMute={setIsMute}
+                  />
+                </Suspense>
+                <Loader barStyles={{ width: 300, height: 25 }} />
+              </>
             ) : (
               <Navigate to="/login" />
             )
@@ -114,14 +120,17 @@ function App() {
           element={
             !auth ? (
               <>
-                <WaitingRoomLayout>
-                  <WaitingRoom />
-                </WaitingRoomLayout>
-                <Login
-                  setToken={setToken}
-                  setUser={setUser}
-                  setAuth={setAuth}
-                />
+                <Suspense fallback={null}>
+                  <WaitingRoomLayout>
+                    <WaitingRoom />
+                  </WaitingRoomLayout>
+                  <Login
+                    setToken={setToken}
+                    setUser={setUser}
+                    setAuth={setAuth}
+                  />
+                </Suspense>
+                <Loader barStyles={{ width: 300, height: 25 }} />
               </>
             ) : (
               <Navigate to="/" />
@@ -134,22 +143,27 @@ function App() {
             !auth ? (
               <Login setToken={setToken} setUser={setUser} setAuth={setAuth} />
             ) : (
-              <GameLayout>
-                <BackButton onClick={backToMain}>
-                  <BackSVGGame />
-                </BackButton>
-                <GameRoom
-                  hexCode={hexCode}
-                  user={user}
-                  position={[0, 0, 0]}
-                  isGameMode={isGameMode}
-                  setIsGameMode={setIsGameMode}
-                  myData={myData}
-                  setMyData={setMyData}
-                  isMute={isMute}
-                  setIsMute={setIsMute}
-                />
-              </GameLayout>
+              <>
+                <GameLayout>
+                  <BackButton onClick={backToMain}>
+                    <BackSVGGame />
+                  </BackButton>
+                  <Suspense fallback={null}>
+                    <GameRoom
+                      hexCode={hexCode}
+                      user={user}
+                      position={[0, 0, 0]}
+                      isGameMode={isGameMode}
+                      setIsGameMode={setIsGameMode}
+                      myData={myData}
+                      setMyData={setMyData}
+                      isMute={isMute}
+                      setIsMute={setIsMute}
+                    />
+                  </Suspense>
+                  <Loader barStyles={{ width: 300, height: 25 }} />
+                </GameLayout>
+              </>
             )
           }
         />

--- a/src/components/GameRoom/index.js
+++ b/src/components/GameRoom/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, Suspense } from "react";
 import { useNavigate } from "react-router-dom";
 import { Canvas } from "@react-three/fiber";
 import { Stars } from "@react-three/drei";

--- a/src/utils/getRandomHex.js
+++ b/src/utils/getRandomHex.js
@@ -1,5 +1,10 @@
 function getRandomColor() {
-  return "#" + Math.floor(Math.random() * 16777215).toString(16);
+  return (
+    "#" +
+    Math.floor(Math.random() * 0xffffff)
+      .toString(16)
+      .padEnd(6, "0")
+  );
 }
 
 export default getRandomColor;


### PR DESCRIPTION
## 개요

- [칸반링크](https://www.notion.so/vanillacoding/ee8da12827364a4a81970133286282ed)
- 저희 프로젝트 특성 상 3d오브젝트 파일의 크기가 커서 로딩시간이 깁니다. 사용자가 보기에 프로그램이 멈췄다고 판단 할 수도 있다고 생각해서 로딩화면을 추가하였습니다.
로딩화면 구현은 리액트 18버전의 Suspense를 이용해서 컴포넌트가 로딩 완료되기 전 까지 로딩화면을 보여주도록 설정하였습니다.

## 작업사항

- 변경사항에 대해서 필요시 스크린샷
<img width="1440" alt="스크린샷 2022-06-17 오후 10 44 47" src="https://user-images.githubusercontent.com/102529818/174310719-3fe8aaf0-033d-4519-86e1-a8caebceae89.png">

## 변경로직

- 로딩화면 추가.
